### PR TITLE
feat: add portuguese translation

### DIFF
--- a/core/src/locale/index.js
+++ b/core/src/locale/index.js
@@ -2,11 +2,13 @@ import Mustache from 'mustache'
 import util from '../util'
 import de from './de'
 import en from './en'
+import pt from './pt'
 const { genItems, pad, traverse } = util
 
 const locales = {
   en,
-  de
+  de,
+  pt
 }
 
 class Locale {

--- a/core/src/locale/pt.js
+++ b/core/src/locale/pt.js
@@ -1,0 +1,68 @@
+export default {
+  '*': {
+    prefix: 'Todo(a)',
+    suffix: '',
+    text: 'Desconhecido',
+    '*': {
+      empty: { text: 'todo {{field.id}}' },
+      value: { text: '{{val.text}}' },
+      range: { text: '{{start.text}}-{{end.text}}' },
+      everyX: { text: 'todo {{every.value}}' }
+    },
+    month: {
+      '*': { prefix: 'de' },
+      value: { text: '{{val.alt}}' },
+      range: { text: '{{start.alt}}-{{end.alt}}' },
+      empty: { text: 'todo mês' }
+    },
+    day: {
+      '*': { prefix: 'no(s) dia(s)' },
+      empty: { text: 'todos' }
+    },
+    dayOfWeek: {
+      '*': { prefix: 'de' },
+      empty: { text: 'todos dias da semana' },
+      value: { text: '{{val.alt}}' },
+      range: { text: '{{start.alt}}-{{end.alt}}' }
+    },
+    hour: {
+      '*': { prefix: 'às' },
+      empty: { text: 'cada hora' }
+    },
+    minute: {
+      '*': { prefix: ':' },
+      empty: { text: 'cada minuto' }
+    }
+  },
+  minute: {
+    text: 'Minuto'
+  },
+  hour: {
+    text: 'Hora',
+    minute: {
+      '*': {
+        prefix: 'e',
+        suffix: 'minuto(s)'
+      },
+      empty: { text: 'cada' }
+    }
+  },
+  day: {
+    text: 'Dia'
+  },
+  week: {
+    text: 'Semana'
+  },
+  month: {
+    text: 'Mês',
+    dayOfWeek: {
+      '*': { prefix: 'e de' }
+    }
+  },
+  year: {
+    text: 'Ano',
+    dayOfWeek: {
+      '*': { prefix: 'e de' }
+    }
+  }
+}

--- a/core/test/locale.test.js
+++ b/core/test/locale.test.js
@@ -35,3 +35,39 @@ test('test render', () => {
     }
   })).toBe('1-2')
 })
+
+test('test getLocaleStr pt', () => {
+  const l = getLocale('pt', {
+    custom: {
+      '*': 'bar',
+      message: 'baz'
+    }
+  })
+
+  expect(l.getLocaleStr('year', 'minute', 'empty', 'text')).toBe('cada minuto')
+  expect(l.getLocaleStr('year', 'dayOfWeek', 'value', 'prefix')).toBe('e de')
+  expect(l.getLocaleStr('year', 'minute', 'range', 'prefix')).toBe(':')
+  expect(l.getLocaleStr('custom', 'foo')).toBe('bar')
+  expect(l.getLocaleStr('custom', 'message')).toBe('baz')
+})
+
+test('test render pt', () => {
+  const l = getLocale('pt', {
+    '*': {
+      '*': {
+        '*': {
+          '*': '{{start.text}}-{{end.text}}'
+        }
+      }
+    }
+  })
+
+  expect(l.render('period', 'field', 'type', 'pos', {
+    start: {
+      text: '1'
+    },
+    end: {
+      text: '2'
+    }
+  })).toBe('1-2')
+})


### PR DESCRIPTION
Adds a "pt" locale for portuguese translation of the texts.

It should work for both Brazillian and European portuguese.

As discussed in #9.