### PR TITLE
feat: add korean translation

### DIFF
--- a/core/src/locale/index.ts
+++ b/core/src/locale/index.ts
@@ -9,6 +9,7 @@ import es from './es'
 import fr from './fr'
 import hi from './hi'
 import ja from './ja'
+import ko from './ko'
 import pt from './pt'
 import ru from './ru'
 import type { Localization } from './types'
@@ -26,6 +27,7 @@ const locales: Record<string, Localization> = {
   fr,
   hi,
   ja,
+  ko,
 }
 
 class Locale {

--- a/core/src/locale/ko.ts
+++ b/core/src/locale/ko.ts
@@ -1,0 +1,61 @@
+import type { Localization } from './types'
+
+const locale: Localization = {
+  '*': {
+    prefix: '매',
+    suffix: '',
+    text: '알 수 없음',
+    '*': {
+      value: { text: '{{value.text}}' },
+      range: { text: '{{start.text}}-{{end.text}}' },
+      everyX: { text: '{{every.value}}마다' },
+    },
+    month: {
+      '*': { prefix: '에' },
+      empty: { prefix: '의', text: '매월' },
+      value: { text: '{{value.alt}}' },
+      range: { text: '{{start.alt}}-{{end.alt}}' },
+    },
+    day: {
+      '*': { prefix: '의' },
+      empty: { prefix: '에', text: '매일' },
+      everyX: { prefix: '', text: '{{every.value}}일마다' },
+      noSpecific: { prefix: '에', text: '특정한 날 없음' },
+    },
+    dayOfWeek: {
+      '*': { prefix: '의' },
+      empty: { prefix: '에', text: '매주' },
+      value: { text: '{{value.alt}}' },
+      range: { text: '{{start.alt}}-{{end.alt}}' },
+      noSpecific: { prefix: '과', text: '특정한 요일 없음' },
+    },
+    hour: {
+      '*': { prefix: '의' },
+      empty: { prefix: '에', text: '매시' },
+      everyX: { prefix: '', text: '{{every.value}}시간마다' },
+    },
+    minute: {
+      '*': { prefix: ':' },
+      empty: { text: '매분' },
+      everyX: { prefix: '', text: '{{every.value}}분마다' },
+    },
+    second: {
+      '*': { prefix: ':' },
+      empty: { text: '매초' },
+      everyX: { prefix: '', text: '{{every.value}}초마다' },
+    },
+  },
+  minute: { text: '분' },
+  hour: { text: '시', minute: { '*': { prefix: '에', suffix: '분' }, empty: { text: '매' } } },
+  day: { prefix: '매', text: '일' },
+  week: { text: '주' },
+  month: { prefix: '매', text: '월' },
+  year: { prefix: '매', text: '년' },
+
+  //quartz format
+  'q-second': { text: '초' },
+  'q-minute': { text: '분', second: { '*': { prefix: '와' } } },
+  'q-hour': { text: '시', minute: { '*': { prefix: '와' } }, second: { '*': { prefix: '와' } } },
+}
+
+export default locale


### PR DESCRIPTION
Added Korean translation.
There was no problem when I tested it.

**screenshot #1**
![image](https://github.com/abichinger/vue-js-cron/assets/6451589/d7486a8a-58e9-47ca-b627-59339bfcf886)

**screenshot #2**
![image](https://github.com/abichinger/vue-js-cron/assets/6451589/14d502b2-4e61-4916-95c9-940f635c7d37)

Please review.