### PR TITLE
feat: add italian translation

### DIFF
--- a/core/src/locale/index.ts
+++ b/core/src/locale/index.ts
@@ -9,6 +9,7 @@ import es from './es'
 import fr from './fr'
 import he from './he'
 import hi from './hi'
+import it from './it'
 import ja from './ja'
 import ko from './ko'
 import pt from './pt'
@@ -29,6 +30,7 @@ const locales: Record<string, Localization> = {
   hi,
   ja,
   ko,
+  it,
 }
 
 class L10nEngine {

--- a/core/src/locale/it.ts
+++ b/core/src/locale/it.ts
@@ -1,0 +1,67 @@
+import type { Localization } from './types'
+
+/**
+ * French localization generated with GPT-4
+ */
+const locale: Localization = {
+    '*': {
+    prefix: 'Tutti',
+    suffix: '',
+    text: 'Sconosciuto',
+    '*': {
+      value: { text: '{{value.text}}' },
+      range: { text: '{{start.text}}-{{end.text}}' },
+      step: { text: 'ogni {{step.value}}' },
+    },
+    month: {
+      '*': { prefix: 'in' },
+      any: { prefix: 'in', text: 'ogni mese' },
+      value: { text: '{{value.alt}}' },
+      range: { text: '{{start.alt}}-{{end.alt}}' },
+    },
+    day: {
+      '*': { prefix: 'il' },
+      any: { prefix: 'il', text: 'ogni giorno' },
+      step: { prefix: '', text: 'ogni {{step.value}} giorni' },
+      noSpecific: { prefix: 'il', text: 'nessun giorno specifico' },
+    },
+    dayOfWeek: {
+      '*': { prefix: 'il' },
+      any: { prefix: 'il', text: 'ogni giorno della settimana' },
+      value: { text: '{{value.alt}}' },
+      range: { text: '{{start.alt}}-{{end.alt}}' },
+      noSpecific: { prefix: 'e', text: 'nessun giorno della settimana specifico' },
+    },
+    hour: {
+      '*': { prefix: 'alle' },
+      any: { prefix: 'alle', text: 'ogni ora' },
+      step: { prefix: '', text: 'ogni {{step.value}} ore' },
+    },
+    minute: {
+      '*': { prefix: ':' },
+      any: { text: 'ogni minuto' },
+      step: { prefix: '', text: 'ogni {{step.value}} minuti' },
+    },
+    second: {
+      '*': { prefix: ':' },
+      any: { text: 'ogni secondo' },
+      step: { prefix: '', text: 'ogni {{step.value}} secondi' },
+    },
+  },
+  minute: { text: 'Minuto' },
+  hour: {
+    text: 'Ora',
+    minute: { '*': { prefix: 'al', suffix: 'minuto/i' }, any: { text: 'tutti' } },
+  },
+  day: { prefix: 'Tutti', text: 'Giorno' },
+  week: { text: 'Settimana' },
+  month: { prefix: 'Tutti', text: 'Mese' },
+  year: { prefix: 'Tutti', text: 'Anno' },
+
+  //quartz format
+  'q-second': { text: 'Secondo' },
+  'q-minute': { text: 'Minuto', second: { '*': { prefix: 'e' } } },
+  'q-hour': { text: 'Ora', minute: { '*': { prefix: 'e' } }, second: { '*': { prefix: 'e' } } },
+}
+
+export default locale


### PR DESCRIPTION
Hi, I've just added the italian translation for the Localization object. I believe I've followed all the required guidelines for this kind of PR, but let me know if something miss.

In the PR that you pointed to "mirror" (the portoguese lang one) there is also a test section, but I saw that the test folder was moved, and I think that only this language hase its own tests, so I didn't generated the italian ones.

Let me know if everything is correct. Thanks for your work