### PR TITLE
feat(core): support special day of month values L and W

### DIFF
--- a/core/src/__tests__/cron.spec.ts
+++ b/core/src/__tests__/cron.spec.ts
@@ -1,10 +1,34 @@
-import { arrayToSegment, cronToSegment } from '@/cron'
-import { FieldWrapper, type CronFormat } from '@/types'
+import {
+  arrayToSegment,
+  cronToSegment,
+  defaultArraySegmentFactories,
+  defaultSegmentFactories,
+  specialDayArraySegmentFactories,
+  specialDaySegmentFactories,
+} from '@/cron'
+import { FieldWrapper, type CronFormat, type FieldValue } from '@/types'
 import { genItems } from '@/util'
 import { describe, expect, it } from 'vitest'
 
 const r = (min: number, max: number, format: CronFormat = 'crontab') => {
   return new FieldWrapper({ id: 'fieldId', items: genItems(min, max) }, { format })
+}
+
+/** day of month field with support for `L` and `W` */
+const day = (format: CronFormat = 'quartz') => {
+  return new FieldWrapper(
+    {
+      id: 'day',
+      items: genItems(1, 31),
+      specialItems: [
+        { value: 'L', text: 'L', alt: 'the last day' },
+        { value: 'LW', text: 'LW', alt: 'the last weekday' },
+      ],
+      segmentFactories: [...defaultSegmentFactories, ...specialDaySegmentFactories],
+      arraySegmentFactories: [...defaultArraySegmentFactories, ...specialDayArraySegmentFactories],
+    },
+    { format },
+  )
 }
 
 describe('segments', () => {
@@ -52,5 +76,84 @@ describe('segments', () => {
     expect(arrayToCron([1, 2, 5, 8, 9, 10], r(1, 10))).toEqual('1-2,5,8-10')
     expect(arrayToCron([5, 7, 9], r(1, 10, 'quartz'))).toEqual('5/2')
     expect(arrayToCron([5, 7, 9], r(1, 10))).toEqual('5-9/2')
+  })
+})
+
+describe('special day values', () => {
+  const cronToArray = (cron: string, field: FieldWrapper) => {
+    return cronToSegment(cron, field)?.toArray() ?? null
+  }
+  const arrayToCron = (arr: FieldValue[], field: FieldWrapper) => {
+    return arrayToSegment(arr, field)?.toCron() ?? null
+  }
+  const patternOf = (cron: string, field: FieldWrapper) => {
+    return cronToSegment(cron, field)?.type ?? null
+  }
+
+  it('cronToSegment', () => {
+    expect(cronToArray('L', day())).toEqual(['L'])
+    expect(cronToArray('L-1', day())).toEqual(['L-1'])
+    expect(cronToArray('L-30', day())).toEqual(['L-30'])
+    expect(cronToArray('LW', day())).toEqual(['LW'])
+    expect(cronToArray('1W', day())).toEqual(['1W'])
+    expect(cronToArray('15W', day())).toEqual(['15W'])
+    expect(cronToArray('31W', day())).toEqual(['31W'])
+
+    // values of the field are still supported
+    expect(cronToArray('*', day())).toEqual([])
+    expect(cronToArray('2-4', day())).toEqual([2, 3, 4])
+    expect(cronToArray('*/10', day())).toEqual([1, 11, 21, 31])
+
+    expect(cronToArray('W', day())).toBe(null)
+    expect(cronToArray('LL', day())).toBe(null)
+    expect(cronToArray('L-0', day())).toBe(null)
+    expect(cronToArray('L-31', day())).toBe(null)
+    expect(cronToArray('0W', day())).toBe(null)
+    expect(cronToArray('32W', day())).toBe(null)
+    // special values can't be part of a list
+    expect(cronToArray('L,5', day())).toBe(null)
+    expect(cronToArray('5,L', day())).toBe(null)
+    expect(cronToArray('L,LW', day())).toBe(null)
+  })
+
+  it('patterns', () => {
+    expect(patternOf('L', day())).toBe('lastDay')
+    expect(patternOf('L-3', day())).toBe('lastDayOffset')
+    expect(patternOf('LW', day())).toBe('lastWeekday')
+    expect(patternOf('15W', day())).toBe('nearestWeekday')
+  })
+
+  it('arrayToSegment', () => {
+    expect(arrayToCron(['L'], day())).toEqual('L')
+    expect(arrayToCron(['L-3'], day())).toEqual('L-3')
+    expect(arrayToCron(['LW'], day())).toEqual('LW')
+    expect(arrayToCron(['15W'], day())).toEqual('15W')
+
+    // values of the field are still supported
+    expect(arrayToCron([], day())).toEqual('*')
+    expect(arrayToCron([2, 3, 4], day())).toEqual('2-4')
+    expect(arrayToCron([1, 11, 21, 31], day())).toEqual('*/10')
+
+    // special values can't be combined with other values
+    expect(arrayToCron(['L', 5], day())).toBe(null)
+    expect(arrayToCron(['L', 'LW'], day())).toBe(null)
+    expect(arrayToCron(['L-0'], day())).toBe(null)
+  })
+
+  it('round trip', () => {
+    for (const cron of ['L', 'L-1', 'L-3', 'LW', '1W', '15W', '*', '2-4', '*/10']) {
+      const segment = cronToSegment(cron, day())
+      expect(segment).not.toBe(null)
+      expect(arrayToCron(segment!.toArray(), day())).toEqual(cron)
+    }
+  })
+
+  it('disabled without opt-in', () => {
+    // the default factories don't support `L` and `W`
+    for (const cron of ['L', 'L-3', 'LW', '15W']) {
+      expect(cronToArray(cron, r(1, 31))).toBe(null)
+      expect(cronToArray(cron, r(1, 31, 'quartz'))).toBe(null)
+      expect(arrayToCron([cron], r(1, 31))).toBe(null)
+    }
   })
 })

--- a/core/src/__tests__/cron.spec.ts
+++ b/core/src/__tests__/cron.spec.ts
@@ -1,13 +1,7 @@
-import {
-  arrayToSegment,
-  cronToSegment,
-  defaultArraySegmentFactories,
-  defaultSegmentFactories,
-  specialDayArraySegmentFactories,
-  specialDaySegmentFactories,
-} from '@/cron'
+import { withSpecialDays } from '@/components/cron-core'
+import { arrayToSegment, cronToSegment } from '@/cron'
 import { FieldWrapper, type CronFormat, type FieldValue } from '@/types'
-import { genItems } from '@/util'
+import { defaultItems, genItems } from '@/util'
 import { describe, expect, it } from 'vitest'
 
 const r = (min: number, max: number, format: CronFormat = 'crontab') => {
@@ -15,20 +9,10 @@ const r = (min: number, max: number, format: CronFormat = 'crontab') => {
 }
 
 /** day of month field with support for `L` and `W` */
-const day = (format: CronFormat = 'quartz') => {
-  return new FieldWrapper(
-    {
-      id: 'day',
-      items: genItems(1, 31),
-      specialItems: [
-        { value: 'L', text: 'L', alt: 'the last day' },
-        { value: 'LW', text: 'LW', alt: 'the last weekday' },
-      ],
-      segmentFactories: [...defaultSegmentFactories, ...specialDaySegmentFactories],
-      arraySegmentFactories: [...defaultArraySegmentFactories, ...specialDayArraySegmentFactories],
-    },
-    { format },
-  )
+const day = () => {
+  return new FieldWrapper(withSpecialDays({ id: 'day', items: defaultItems('en').dayItems }), {
+    format: 'quartz',
+  })
 }
 
 describe('segments', () => {

--- a/core/src/__tests__/locale.spec.ts
+++ b/core/src/__tests__/locale.spec.ts
@@ -62,6 +62,28 @@ describe('locale', () => {
     expect(l.getTemplate('custom', 'message')).toBe('baz')
   })
 
+  it('special day values are translated', () => {
+    const codes = ['da', 'de', 'es', 'fr', 'he', 'hi', 'it', 'ja', 'ko', 'pt', 'ru', 'uk', 'zh']
+    const patterns = [
+      FieldPattern.LastDay,
+      FieldPattern.LastDayOffset,
+      FieldPattern.LastWeekday,
+      FieldPattern.NearestWeekday,
+    ]
+    const en = createL10n('en')
+
+    // the localization of a locale is merged into the english one,
+    // therefore a missing translation shows up as english text
+    for (const code of codes) {
+      const l = createL10n(code)
+      for (const pattern of patterns) {
+        const template = l.getTemplate('*', 'day', pattern, TextPosition.Text)
+        expect(template).not.toBe('')
+        expect(template).not.toBe(en.getTemplate('*', 'day', pattern, TextPosition.Text))
+      }
+    }
+  })
+
   it('render', () => {
     const l = createL10n('en', {
       '*': {

--- a/core/src/components/__tests__/cron-core.spec.ts
+++ b/core/src/components/__tests__/cron-core.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, test } from 'vitest'
 
+import { createL10n } from '@/locale'
 import type { CronFormat, Period } from '@/types'
 import { mount } from '@vue/test-utils'
 import { defineComponent, nextTick } from 'vue'
@@ -9,6 +10,7 @@ import {
   findFirstPeriod,
   setupCron,
   useCron,
+  withSpecialDays,
 } from '../cron-core'
 
 type UseCronReturn = ReturnType<typeof useCron>
@@ -92,6 +94,30 @@ describe('useCron', () => {
         value: '59 59 23 ? * 1',
         period: 'week',
         expected: `Every Week on Mon at 23 : 59 : 59`,
+      },
+      {
+        format: 'quartz',
+        value: '0 0 0 L * ?',
+        period: 'month',
+        expected: `Every Month on the last day and no specific day of the week at 00 : 00 : 00`,
+      },
+      {
+        format: 'quartz',
+        value: '0 0 0 L-3 * ?',
+        period: 'month',
+        expected: `Every Month on 3 day(s) before the last day and no specific day of the week at 00 : 00 : 00`,
+      },
+      {
+        format: 'spring',
+        value: '0 0 0 LW * ?',
+        period: 'month',
+        expected: `Every Month on the last weekday and no specific day of the week at 00 : 00 : 00`,
+      },
+      {
+        format: 'quartz',
+        value: '0 0 0 15W * ?',
+        period: 'month',
+        expected: `Every Month on the weekday nearest to day 15 and no specific day of the week at 00 : 00 : 00`,
       },
     ]
 
@@ -220,4 +246,58 @@ describe('findFirstPeriod', () => {
       expect(findFirstPeriod(t.periods ?? periods, t.cron, t.fields ?? fields)?.id).toBe(t.expected)
     })
   }
+})
+
+describe('special day values', () => {
+  const crontabFields = () => {
+    const l10n = createL10n('en')
+    return new DefaultCronOptions()
+      .fields('crontab', 'en', l10n)
+      .map((field) => (field.id === 'day' ? withSpecialDays(field, l10n) : field))
+  }
+
+  it('round trip', async () => {
+    const values = ['0 0 0 L * ?', '0 0 0 L-3 * ?', '0 0 0 LW * ?', '0 0 0 15W * ?']
+
+    for (const value of values) {
+      const cron = useCron({ format: 'quartz', initialValue: value })
+      await nextTick()
+
+      expect(cron.error.value).toEqual('')
+      expect(cron.cron.value).toEqual(value)
+    }
+  })
+
+  it('crontab is unchanged without opt-in', async () => {
+    const cron = useCron({ format: 'crontab', initialValue: '0 0 L * *' })
+    await nextTick()
+
+    expect(cron.error.value).toEqual('L is not a valid cron segment (day)')
+    expect(cron.cron.value).toEqual('0 0 L * *')
+    expect(cron.segments[2].items.length).toEqual(31)
+  })
+
+  it('opt-in for crontab', async () => {
+    const cron = useCron({
+      format: 'crontab',
+      initialValue: '0 0 L * *',
+      fields: crontabFields(),
+    })
+    await nextTick()
+
+    expect(cron.error.value).toEqual('')
+    expect(cron.cron.value).toEqual('0 0 L * *')
+    expect(cron.segments[2].text.value).toEqual('the last day')
+    expect(cron.segments[2].items.length).toEqual(33)
+  })
+
+  it('selecting a day replaces the special value', async () => {
+    const cron = useCron({ format: 'quartz', initialValue: '0 0 0 L * ?' })
+    await nextTick()
+
+    cron.segments[3].select([5])
+    await nextTick()
+
+    expect(cron.cron.value).toEqual('0 0 0 5 * ?')
+  })
 })

--- a/core/src/components/__tests__/cron-core.spec.ts
+++ b/core/src/components/__tests__/cron-core.spec.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, test } from 'vitest'
 
-import { createL10n } from '@/locale'
 import type { CronFormat, Period } from '@/types'
 import { mount } from '@vue/test-utils'
 import { defineComponent, nextTick } from 'vue'
@@ -250,10 +249,9 @@ describe('findFirstPeriod', () => {
 
 describe('special day values', () => {
   const crontabFields = () => {
-    const l10n = createL10n('en')
     return new DefaultCronOptions()
-      .fields('crontab', 'en', l10n)
-      .map((field) => (field.id === 'day' ? withSpecialDays(field, l10n) : field))
+      .fields('crontab', 'en')
+      .map((field) => (field.id === 'day' ? withSpecialDays(field) : field))
   }
 
   it('round trip', async () => {

--- a/core/src/components/__tests__/cron-segment.spec.ts
+++ b/core/src/components/__tests__/cron-segment.spec.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
 import { createL10n } from '@/locale'
-import { FieldWrapper } from '@/types'
+import { FieldWrapper, type FieldValue, type SelectItem } from '@/types'
 import { defaultItems } from '@/util'
-import { nextTick, ref } from 'vue'
-import { useCronSegment } from '../cron-segment'
+import { nextTick, ref, watch } from 'vue'
+import { withSpecialDays } from '../cron-core'
+import { useCronSegment, type UseCronSegmentReturn } from '../cron-segment'
+import { useSelect } from '../select'
 
 const f = () => {
   const fieldDesc = new FieldWrapper(
@@ -21,6 +23,22 @@ const f = () => {
     l10n: createL10n('en'),
     field: fieldDesc,
     period: ref(period),
+    initialCron: '*',
+  })
+}
+
+/** day of month segment with support for `L` and `W` */
+const day = () => {
+  const l10n = createL10n('en')
+  const field = new FieldWrapper(
+    withSpecialDays({ id: 'day', items: defaultItems('en').dayItems }, l10n),
+    { format: 'quartz' },
+  )
+
+  return useCronSegment({
+    l10n,
+    field,
+    period: ref({ id: 'month', value: [] }),
     initialCron: '*',
   })
 }
@@ -65,5 +83,136 @@ describe('CronSegment', () => {
       expect(cron.value).toEqual(t.expectedCron)
       expect(text.value).toEqual(t.expectedText)
     }
+  })
+})
+
+describe('CronSegment - special values', () => {
+  it('special items are selectable', () => {
+    const { items } = day()
+
+    expect(items.length).toEqual(33)
+    expect(items.slice(31)).toEqual([
+      { value: 'L', text: 'L', alt: 'the last day' },
+      { value: 'LW', text: 'LW', alt: 'the last weekday' },
+    ])
+  })
+
+  it('cron/array converted properly', async () => {
+    const { cron, selected, text, error } = day()
+
+    const tests = [
+      { cron: 'L', expectedArr: ['L'], expectedText: 'the last day' },
+      { cron: 'L-3', expectedArr: ['L-3'], expectedText: '3 day(s) before the last day' },
+      { cron: 'LW', expectedArr: ['LW'], expectedText: 'the last weekday' },
+      { cron: '15W', expectedArr: ['15W'], expectedText: 'the weekday nearest to day 15' },
+    ]
+
+    for (const t of tests) {
+      cron.value = t.cron
+      await nextTick()
+
+      expect(error.value).toEqual('')
+      expect(selected.value).toEqual(t.expectedArr)
+      expect(cron.value).toEqual(t.cron)
+      expect(text.value).toEqual(t.expectedText)
+    }
+  })
+
+  it('special values are exclusive', async () => {
+    const { cron, selected, select } = day()
+
+    select([1, 2])
+    await nextTick()
+    expect(cron.value).toEqual('1-2')
+
+    // selecting a special value clears the other values
+    select([1, 2, 'L'])
+    await nextTick()
+    expect(selected.value).toEqual(['L'])
+    expect(cron.value).toEqual('L')
+
+    // selecting a value clears the special value
+    select(['L', 5])
+    await nextTick()
+    expect(selected.value).toEqual([5])
+    expect(cron.value).toEqual('5')
+  })
+
+  it('special values are kept, while nothing is selected', async () => {
+    const { cron, select } = day()
+
+    // `L-3` and `15W` aren't part of the items, therefore they can't be selected
+    for (const value of ['L-3', '15W']) {
+      cron.value = value
+      await nextTick()
+
+      select([])
+      await nextTick()
+      expect(cron.value).toEqual(value)
+    }
+  })
+})
+
+/** connects a segment to a select, the same way the prebuilt components do */
+const selectOf = (segment: UseCronSegmentReturn) => {
+  const s = useSelect<SelectItem, FieldValue>({ items: segment.items, multiple: true })
+
+  watch(s.selected, () => {
+    segment.select(s.selected.value as FieldValue[])
+  })
+  watch(segment.selected, (value) => s.setValues(value), { immediate: true })
+
+  return s
+}
+
+describe('CronSegment - select', () => {
+  it('special values can be selected', async () => {
+    const segment = day()
+    const select = selectOf(segment)
+
+    const lastDay = segment.items.find((item) => item.value === 'L')!
+    select.select(lastDay)
+    await nextTick()
+
+    expect(segment.cron.value).toEqual('L')
+    expect(segment.text.value).toEqual('the last day')
+    expect(select.selectedStr.value).toEqual('L')
+
+    // selecting a day replaces the special value
+    select.select(segment.items[4])
+    await nextTick()
+
+    expect(segment.cron.value).toEqual('5')
+    expect(select.selectedStr.value).toEqual('5')
+  })
+
+  it('special values of the cron expression are selected', async () => {
+    const segment = day()
+    const select = selectOf(segment)
+
+    segment.cron.value = 'L'
+    await nextTick()
+    await nextTick()
+
+    expect(segment.cron.value).toEqual('L')
+    expect(segment.selected.value).toEqual(['L'])
+    expect(select.has(segment.items.find((item) => item.value === 'L')!)).toBe(true)
+  })
+
+  it('values without an item are kept', async () => {
+    const segment = day()
+    const select = selectOf(segment)
+
+    select.select(segment.items[4])
+    await nextTick()
+    expect(segment.cron.value).toEqual('5')
+
+    // `L-3` isn't part of the items, therefore the select clears its values
+    segment.cron.value = 'L-3'
+    await nextTick()
+
+    expect(segment.cron.value).toEqual('L-3')
+    expect(segment.text.value).toEqual('3 day(s) before the last day')
+    expect(select.values.size).toEqual(0)
   })
 })

--- a/core/src/components/__tests__/cron-segment.spec.ts
+++ b/core/src/components/__tests__/cron-segment.spec.ts
@@ -31,7 +31,7 @@ const f = () => {
 const day = () => {
   const l10n = createL10n('en')
   const field = new FieldWrapper(
-    withSpecialDays({ id: 'day', items: defaultItems('en').dayItems }, l10n),
+    withSpecialDays({ id: 'day', items: defaultItems('en').dayItems }),
     { format: 'quartz' },
   )
 
@@ -92,8 +92,8 @@ describe('CronSegment - special values', () => {
 
     expect(items.length).toEqual(33)
     expect(items.slice(31)).toEqual([
-      { value: 'L', text: 'L', alt: 'the last day' },
-      { value: 'LW', text: 'LW', alt: 'the last weekday' },
+      { value: 'L', text: 'L', alt: '' },
+      { value: 'LW', text: 'LW', alt: '' },
     ])
   })
 

--- a/core/src/components/cron-core.ts
+++ b/core/src/components/cron-core.ts
@@ -1,5 +1,15 @@
-import { AnySegment, NoSpecificSegment, RangeSegment, StepSegment, ValueSegment } from '@/cron'
-import { createL10n } from '@/locale'
+import {
+  AnySegment,
+  defaultArraySegmentFactories,
+  defaultSegmentFactories,
+  NoSpecificSegment,
+  RangeSegment,
+  specialDayArraySegmentFactories,
+  specialDaySegmentFactories,
+  StepSegment,
+  ValueSegment,
+} from '@/cron'
+import { createL10n, L10nEngine } from '@/locale'
 import type { Localization } from '@/locale/types'
 import {
   computed,
@@ -10,7 +20,15 @@ import {
   type PropType,
   type SetupContext,
 } from 'vue'
-import { FieldWrapper, TextPosition, type CronFormat, type Field, type Period } from '../types'
+import {
+  FieldPattern,
+  FieldWrapper,
+  TextPosition,
+  type CronFormat,
+  type Field,
+  type Period,
+  type SpecialItem,
+} from '../types'
 import { defaultItems } from '../util'
 import { useCronSegment, type UseCronSegmentReturn } from './cron-segment'
 
@@ -36,6 +54,59 @@ function isDefined<T>(obj: T | undefined): obj is T {
   return obj !== undefined
 }
 
+/**
+ * Items of the special values `L` (last day of the month)
+ * and `LW` (last weekday of the month)
+ *
+ * Note: The cron token is used as the text of the item, because the items of a field
+ * are displayed in a grid. The selected value is spelled out by the editor itself.
+ *
+ * @param l10n - localization engine, used to translate the items
+ * @param fieldId - id of the field, the items belong to
+ */
+export function specialDayItems(l10n: L10nEngine, fieldId: string = 'day'): SpecialItem[] {
+  const patterns: { value: string; pattern: FieldPattern }[] = [
+    { value: 'L', pattern: FieldPattern.LastDay },
+    { value: 'LW', pattern: FieldPattern.LastWeekday },
+  ]
+
+  return patterns.map(({ value, pattern }) => {
+    return {
+      value,
+      text: value,
+      alt: l10n.getTemplate('*', fieldId, pattern, TextPosition.Text),
+    }
+  })
+}
+
+/**
+ * Adds support for the special values `L`, `L-<n>`, `LW` and `<n>W` of the day of month field.
+ * These values are part of the quartz and spring format. Use this function to enable them
+ * for other formats.
+ *
+ * @example
+ * ```ts
+ * const l10n = createL10n('en')
+ * const fields = new DefaultCronOptions()
+ *   .fields('crontab', 'en', l10n)
+ *   .map((field) => (field.id === 'day' ? withSpecialDays(field, l10n) : field))
+ * ```
+ */
+export function withSpecialDays(field: Field, l10n: L10nEngine = createL10n('en')): Field {
+  return {
+    ...field,
+    specialItems: [...(field.specialItems ?? []), ...specialDayItems(l10n, field.id)],
+    segmentFactories: [
+      ...(field.segmentFactories ?? defaultSegmentFactories),
+      ...specialDaySegmentFactories,
+    ],
+    arraySegmentFactories: [
+      ...(field.arraySegmentFactories ?? defaultArraySegmentFactories),
+      ...specialDayArraySegmentFactories,
+    ],
+  }
+}
+
 export class DefaultCronOptions {
   locale = 'en'
 
@@ -45,7 +116,7 @@ export class DefaultCronOptions {
     return createCron(fields)
   }
 
-  fields(format: CronFormat, locale: string): Field[] {
+  fields(format: CronFormat, locale: string, l10n: L10nEngine = createL10n(locale)): Field[] {
     const isQuartz = format == 'quartz' || format == 'spring'
     const items = defaultItems(locale, format)
 
@@ -63,24 +134,27 @@ export class DefaultCronOptions {
       }
     }
 
+    const dayField: Field = {
+      id: 'day',
+      items: items.dayItems,
+      onChange: isQuartz ? setNoSpecific('dayOfWeek') : undefined,
+      segmentFactories: isQuartz
+        ? [
+            AnySegment.fromString,
+            NoSpecificSegment.fromString,
+            StepSegment.fromString,
+            RangeSegment.fromString,
+            ValueSegment.fromString,
+          ]
+        : undefined,
+    }
+
     return [
       ...(isQuartz ? [{ id: 'second', items: items.secondItems }] : []),
       { id: 'minute', items: items.minuteItems },
       { id: 'hour', items: items.hourItems },
-      {
-        id: 'day',
-        items: items.dayItems,
-        onChange: isQuartz ? setNoSpecific('dayOfWeek') : undefined,
-        segmentFactories: isQuartz
-          ? [
-              AnySegment.fromString,
-              NoSpecificSegment.fromString,
-              StepSegment.fromString,
-              RangeSegment.fromString,
-              ValueSegment.fromString,
-            ]
-          : undefined,
-      },
+      // `L` and `W` are only supported by the quartz and spring format
+      isQuartz ? withSpecialDays(dayField, l10n) : dayField,
       { id: 'month', items: items.monthItems },
       {
         id: 'dayOfWeek',
@@ -140,10 +214,11 @@ export function useCron(options: CronOptions) {
 
   const locale = options.locale ?? cronDefaults.locale
   const format = options.format ?? cronDefaults.format
-  const { customLocale, fields = cronDefaults.fields(format, locale) } = options
-  const initialValue = options.initialValue ?? cronDefaults.initialValue(fields)
+  const { customLocale } = options
 
   const l10n = createL10n(locale, customLocale)
+  const { fields = cronDefaults.fields(format, locale, l10n) } = options
+  const initialValue = options.initialValue ?? cronDefaults.initialValue(fields)
   const periods = (options.periods ?? cronDefaults.periods(format)).map((p) => {
     return {
       ...p,

--- a/core/src/components/cron-core.ts
+++ b/core/src/components/cron-core.ts
@@ -9,7 +9,7 @@ import {
   StepSegment,
   ValueSegment,
 } from '@/cron'
-import { createL10n, L10nEngine } from '@/locale'
+import { createL10n } from '@/locale'
 import type { Localization } from '@/locale/types'
 import {
   computed,
@@ -21,7 +21,6 @@ import {
   type SetupContext,
 } from 'vue'
 import {
-  FieldPattern,
   FieldWrapper,
   TextPosition,
   type CronFormat,
@@ -55,47 +54,26 @@ function isDefined<T>(obj: T | undefined): obj is T {
 }
 
 /**
- * Items of the special values `L` (last day of the month)
- * and `LW` (last weekday of the month)
- *
- * Note: The cron token is used as the text of the item, because the items of a field
- * are displayed in a grid. The selected value is spelled out by the editor itself.
- *
- * @param l10n - localization engine, used to translate the items
- * @param fieldId - id of the field, the items belong to
- */
-export function specialDayItems(l10n: L10nEngine, fieldId: string = 'day'): SpecialItem[] {
-  const patterns: { value: string; pattern: FieldPattern }[] = [
-    { value: 'L', pattern: FieldPattern.LastDay },
-    { value: 'LW', pattern: FieldPattern.LastWeekday },
-  ]
-
-  return patterns.map(({ value, pattern }) => {
-    return {
-      value,
-      text: value,
-      alt: l10n.getTemplate('*', fieldId, pattern, TextPosition.Text),
-    }
-  })
-}
-
-/**
  * Adds support for the special values `L`, `L-<n>`, `LW` and `<n>W` of the day of month field.
  * These values are part of the quartz and spring format. Use this function to enable them
  * for other formats.
  *
  * @example
  * ```ts
- * const l10n = createL10n('en')
  * const fields = new DefaultCronOptions()
- *   .fields('crontab', 'en', l10n)
- *   .map((field) => (field.id === 'day' ? withSpecialDays(field, l10n) : field))
+ *   .fields('crontab', 'en')
+ *   .map((field) => (field.id === 'day' ? withSpecialDays(field) : field))
  * ```
  */
-export function withSpecialDays(field: Field, l10n: L10nEngine = createL10n('en')): Field {
+export function withSpecialDays(field: Field): Field {
+  const specialDayItems: SpecialItem[] = [
+    { value: 'L', text: 'L', alt: '' },
+    { value: 'LW', text: 'LW', alt: '' },
+  ]
+
   return {
     ...field,
-    specialItems: [...(field.specialItems ?? []), ...specialDayItems(l10n, field.id)],
+    specialItems: [...(field.specialItems ?? []), ...specialDayItems],
     segmentFactories: [
       ...(field.segmentFactories ?? defaultSegmentFactories),
       ...specialDaySegmentFactories,
@@ -116,7 +94,7 @@ export class DefaultCronOptions {
     return createCron(fields)
   }
 
-  fields(format: CronFormat, locale: string, l10n: L10nEngine = createL10n(locale)): Field[] {
+  fields(format: CronFormat, locale: string): Field[] {
     const isQuartz = format == 'quartz' || format == 'spring'
     const items = defaultItems(locale, format)
 
@@ -154,7 +132,7 @@ export class DefaultCronOptions {
       { id: 'minute', items: items.minuteItems },
       { id: 'hour', items: items.hourItems },
       // `L` and `W` are only supported by the quartz and spring format
-      isQuartz ? withSpecialDays(dayField, l10n) : dayField,
+      isQuartz ? withSpecialDays(dayField) : dayField,
       { id: 'month', items: items.monthItems },
       {
         id: 'dayOfWeek',
@@ -217,7 +195,7 @@ export function useCron(options: CronOptions) {
   const { customLocale } = options
 
   const l10n = createL10n(locale, customLocale)
-  const { fields = cronDefaults.fields(format, locale, l10n) } = options
+  const { fields = cronDefaults.fields(format, locale) } = options
   const initialValue = options.initialValue ?? cronDefaults.initialValue(fields)
   const periods = (options.periods ?? cronDefaults.periods(format)).map((p) => {
     return {

--- a/core/src/components/cron-segment.ts
+++ b/core/src/components/cron-segment.ts
@@ -1,6 +1,14 @@
 import { CombinedSegment, arrayToSegment, cronToSegment } from '@/cron'
 import type { L10nEngine } from '@/locale'
-import { TextPosition, type CronSegment, type FieldWrapper, type Period } from '@/types'
+import {
+  isSpecialPattern,
+  isSpecialValue,
+  TextPosition,
+  type CronSegment,
+  type FieldValue,
+  type FieldWrapper,
+  type Period,
+} from '@/types'
 import { ref, watch, type Ref } from 'vue'
 
 export interface FieldOptions {
@@ -15,7 +23,10 @@ export function useCronSegment(options: FieldOptions) {
 
   const cron = ref(initialCron)
   const error = ref('')
-  const selected = ref<number[]>([])
+  const selected = ref<FieldValue[]>([])
+
+  // the segment of the current cron expression
+  let segment: CronSegment | null = null
 
   const text = ref('')
   const prefix = ref('')
@@ -40,20 +51,25 @@ export function useCronSegment(options: FieldOptions) {
   const parseCron = (cron: string) => {
     const seg = cronToSegment(cron, field)
     if (seg != null) {
+      segment = seg
       selected.value = seg.toArray()
       translate(seg)
     } else {
+      segment = null
       error.value = `${cron} is not a valid cron segment (${field.id})`
     }
   }
 
-  const toCron = (value: number[]) => {
-    if (cron.value == '?' && value.length == 0) {
+  const toCron = (value: FieldValue[]) => {
+    // special values, such as `?` or `L`, aren't part of the items of a field.
+    // Therefore they are kept, as long as nothing is selected.
+    if (value.length == 0 && segment !== null && isSpecialPattern(segment.type)) {
       return
     }
 
     const seg = arrayToSegment(value, field)
     if (seg != null) {
+      segment = seg
       cron.value = seg.toCron()
       translate(seg)
     } else {
@@ -63,8 +79,19 @@ export function useCronSegment(options: FieldOptions) {
 
   parseCron(initialCron)
 
-  const select = (evt: number[]) => {
-    const sorted = Array.from(evt).sort((a, b) => {
+  const select = (evt: FieldValue[]) => {
+    const added = evt.filter((value) => !selected.value.includes(value))
+    const special = added.find(isSpecialValue)
+
+    // special values, such as `L`, can't be combined with other values
+    let values = evt
+    if (special !== undefined) {
+      values = [special]
+    } else if (added.length > 0) {
+      values = evt.filter((value) => !isSpecialValue(value))
+    }
+
+    const sorted = Array.from(values).sort((a, b) => {
       return a > b ? 1 : -1
     })
     selected.value = sorted
@@ -87,7 +114,7 @@ export function useCronSegment(options: FieldOptions) {
 
   return {
     id: field.id,
-    items: field.items,
+    items: field.allItems,
     cron,
     selected,
     error,

--- a/core/src/cron.ts
+++ b/core/src/cron.ts
@@ -1,5 +1,22 @@
-import { FieldPattern, FieldWrapper, type CronSegment, type SegmentFromString } from './types'
+import {
+  FieldPattern,
+  FieldWrapper,
+  isSpecialPattern,
+  isSpecialValue,
+  type CronSegment,
+  type FieldItem,
+  type FieldValue,
+  type SegmentFromArray,
+  type SegmentFromString,
+} from './types'
 import { isSquence, range, unimplemented } from './util'
+
+/**
+ * @returns true, if `arr` doesn't contain any special values, such as `L`
+ */
+function isValueArray(arr: FieldValue[]): arr is number[] {
+  return arr.every((value) => !isSpecialValue(value))
+}
 
 class NoSpecificSegment implements CronSegment {
   field: FieldWrapper
@@ -56,9 +73,12 @@ class AnySegment implements CronSegment {
     return new AnySegment(field)
   }
 
-  static fromArray(arr: number[], field: FieldWrapper) {
+  static fromArray(arr: FieldValue[], field: FieldWrapper) {
     const { items } = field
 
+    if (!isValueArray(arr)) {
+      return null
+    }
     if (arr.length === 0) {
       return new AnySegment(field)
     }
@@ -216,8 +236,8 @@ class StepSegment implements CronSegment {
     return new StepSegment(field, step, min, max)
   }
 
-  static fromArray(arr: number[], field: FieldWrapper) {
-    if (arr.length < 3) {
+  static fromArray(arr: FieldValue[], field: FieldWrapper) {
+    if (!isValueArray(arr) || arr.length < 3) {
       return null
     }
 
@@ -268,10 +288,10 @@ class ValueSegment implements CronSegment {
       : null
   }
 
-  static fromArray(arr: number[], field: FieldWrapper) {
+  static fromArray(arr: FieldValue[], field: FieldWrapper) {
     const { min, max } = field
 
-    if (arr.length != 1) {
+    if (!isValueArray(arr) || arr.length != 1) {
       return null
     }
 
@@ -281,6 +301,155 @@ class ValueSegment implements CronSegment {
     }
 
     return value
+  }
+}
+
+/**
+ * Segment of the special value `L` of the day of month field
+ *
+ * - `L` - last day of the month
+ * - `L-3` - 3 days before the last day of the month
+ */
+class LastDaySegment implements CronSegment {
+  static re = /^L(?:-(\d+))?$/
+
+  field: FieldWrapper
+  offset: number
+
+  constructor(field: FieldWrapper, offset: number = 0) {
+    this.field = field
+    this.offset = offset
+  }
+
+  get type() {
+    return this.offset === 0 ? FieldPattern.LastDay : FieldPattern.LastDayOffset
+  }
+
+  toCron() {
+    return this.offset === 0 ? 'L' : `L-${this.offset}`
+  }
+
+  toArray() {
+    return [this.toCron()]
+  }
+
+  get items(): Record<string, FieldItem> {
+    return this.offset === 0 ? {} : { offset: this.field.itemMap[this.offset] }
+  }
+
+  static fromString(str: string, field: FieldWrapper) {
+    const match = LastDaySegment.re.exec(str)
+    if (match === null) {
+      return null
+    }
+    if (match[1] === undefined) {
+      return new LastDaySegment(field)
+    }
+
+    const offset = parseInt(match[1])
+    if (offset < 1 || offset > field.max - field.min) {
+      return null
+    }
+    return new LastDaySegment(field, offset)
+  }
+
+  static fromArray(arr: FieldValue[], field: FieldWrapper) {
+    const [value] = arr
+    return arr.length === 1 && isSpecialValue(value)
+      ? LastDaySegment.fromString(value, field)
+      : null
+  }
+}
+
+/**
+ * Segment of the special value `LW` of the day of month field
+ *
+ * - `LW` - last weekday of the month
+ */
+class LastWeekdaySegment implements CronSegment {
+  static re = /^LW$/
+
+  field: FieldWrapper
+  type: FieldPattern = FieldPattern.LastWeekday
+
+  constructor(field: FieldWrapper) {
+    this.field = field
+  }
+
+  toCron() {
+    return 'LW'
+  }
+
+  toArray() {
+    return [this.toCron()]
+  }
+
+  get items() {
+    return {}
+  }
+
+  static fromString(str: string, field: FieldWrapper) {
+    return LastWeekdaySegment.re.test(str) ? new LastWeekdaySegment(field) : null
+  }
+
+  static fromArray(arr: FieldValue[], field: FieldWrapper) {
+    const [value] = arr
+    return arr.length === 1 && isSpecialValue(value)
+      ? LastWeekdaySegment.fromString(value, field)
+      : null
+  }
+}
+
+/**
+ * Segment of the special value `W` of the day of month field
+ *
+ * - `15W` - weekday nearest to the 15th of the month
+ */
+class NearestWeekdaySegment implements CronSegment {
+  static re = /^(\d+)W$/
+
+  field: FieldWrapper
+  type: FieldPattern = FieldPattern.NearestWeekday
+  day: number
+
+  constructor(field: FieldWrapper, day: number) {
+    this.field = field
+    this.day = day
+  }
+
+  toCron() {
+    return `${this.day}W`
+  }
+
+  toArray() {
+    return [this.toCron()]
+  }
+
+  get items() {
+    return {
+      value: this.field.itemMap[this.day],
+    }
+  }
+
+  static fromString(str: string, field: FieldWrapper) {
+    const match = NearestWeekdaySegment.re.exec(str)
+    if (match === null) {
+      return null
+    }
+
+    const { min, max } = field
+    const day = parseInt(match[1])
+    if (day < min || day > max) {
+      return null
+    }
+    return new NearestWeekdaySegment(field, day)
+  }
+
+  static fromArray(arr: FieldValue[], field: FieldWrapper) {
+    const [value] = arr
+    return arr.length === 1 && isSpecialValue(value)
+      ? NearestWeekdaySegment.fromString(value, field)
+      : null
   }
 }
 
@@ -316,7 +485,7 @@ class CombinedSegment implements CronSegment {
   }
 
   toArray() {
-    const values = new Set<number>()
+    const values = new Set<FieldValue>()
     for (const seg of this.segments) {
       seg.toArray().forEach((value) => values.add(value))
     }
@@ -348,11 +517,21 @@ class CombinedSegment implements CronSegment {
       }
       segments.push(segment)
     }
+
+    // special values, such as `?` or `L`, can't be part of a list
+    if (segments.length > 1 && segments.some((seg) => isSpecialPattern(seg.type))) {
+      return null
+    }
+
     return new CombinedSegment(field, segments)
   }
 
-  static fromArray(arr: number[], field: FieldWrapper) {
+  static fromArray(arr: FieldValue[], field: FieldWrapper) {
     const { min, max } = field
+
+    if (!isValueArray(arr)) {
+      return null
+    }
 
     const minValue = arr[0]
     const maxValue = arr[arr.length - 1]
@@ -381,16 +560,45 @@ class CombinedSegment implements CronSegment {
   }
 }
 
+/**
+ * Default factories to convert a cron segment into a {@link CronSegment}
+ */
+const defaultSegmentFactories: SegmentFromString[] = CombinedSegment.segmentFactories
+
+/**
+ * Default factories to convert the selected values into a {@link CronSegment}
+ */
+const defaultArraySegmentFactories: SegmentFromArray[] = [
+  AnySegment.fromArray,
+  StepSegment.fromArray,
+  CombinedSegment.fromArray,
+]
+
+/**
+ * Factories to parse the special values of the day of month field: `L`, `L-3`, `LW` and `15W`
+ */
+const specialDaySegmentFactories: SegmentFromString[] = [
+  LastWeekdaySegment.fromString,
+  LastDaySegment.fromString,
+  NearestWeekdaySegment.fromString,
+]
+
+/**
+ * Factories to build the special values of the day of month field: `L`, `L-3`, `LW` and `15W`
+ */
+const specialDayArraySegmentFactories: SegmentFromArray[] = [
+  LastWeekdaySegment.fromArray,
+  LastDaySegment.fromArray,
+  NearestWeekdaySegment.fromArray,
+]
+
 function cronToSegment(cron: string, field: FieldWrapper) {
   return CombinedSegment.fromString(cron, field)
 }
 
-function arrayToSegment(arr: number[], field: FieldWrapper) {
-  for (const fromArray of [
-    AnySegment.fromArray,
-    StepSegment.fromArray,
-    CombinedSegment.fromArray,
-  ]) {
+function arrayToSegment(arr: FieldValue[], field: FieldWrapper) {
+  const factories = field.arraySegmentFactories ?? defaultArraySegmentFactories
+  for (const fromArray of factories) {
     const seg = fromArray(arr, field)
     if (seg != null) {
       return seg
@@ -404,8 +612,15 @@ export {
   arrayToSegment,
   CombinedSegment,
   cronToSegment,
+  defaultArraySegmentFactories,
+  defaultSegmentFactories,
+  LastDaySegment,
+  LastWeekdaySegment,
+  NearestWeekdaySegment,
   NoSpecificSegment,
   RangeSegment,
+  specialDayArraySegmentFactories,
+  specialDaySegmentFactories,
   StepSegment,
   ValueSegment,
 }

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -4,8 +4,11 @@ import { CronCore } from './components/cron-core'
 export {
   CronCore,
   cronCoreProps,
+  DefaultCronOptions,
   setupCron,
+  specialDayItems,
   useCron,
+  withSpecialDays,
   type CronContext,
   type CronCoreProps,
   type CronOptions,
@@ -19,10 +22,27 @@ export {
   type SelectOptions,
   type UseSelectReturn,
 } from './components/select'
+export {
+  AnySegment,
+  arrayToSegment,
+  CombinedSegment,
+  cronToSegment,
+  defaultArraySegmentFactories,
+  defaultSegmentFactories,
+  LastDaySegment,
+  LastWeekdaySegment,
+  NearestWeekdaySegment,
+  NoSpecificSegment,
+  RangeSegment,
+  specialDayArraySegmentFactories,
+  specialDaySegmentFactories,
+  StepSegment,
+  ValueSegment,
+} from './cron'
 export { createL10n, L10nEngine } from './locale'
 export type * from './locale/types'
 export type * from './types'
-export { FieldPattern, FieldWrapper, TextPosition } from './types'
+export { FieldPattern, FieldWrapper, isSpecialPattern, isSpecialValue, TextPosition } from './types'
 export { defaultItems, genItems, pad, splitArray, type toText } from './util'
 
 export const CronCorePlugin = {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -6,7 +6,6 @@ export {
   cronCoreProps,
   DefaultCronOptions,
   setupCron,
-  specialDayItems,
   useCron,
   withSpecialDays,
   type CronContext,

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -21,23 +21,6 @@ export {
   type SelectOptions,
   type UseSelectReturn,
 } from './components/select'
-export {
-  AnySegment,
-  arrayToSegment,
-  CombinedSegment,
-  cronToSegment,
-  defaultArraySegmentFactories,
-  defaultSegmentFactories,
-  LastDaySegment,
-  LastWeekdaySegment,
-  NearestWeekdaySegment,
-  NoSpecificSegment,
-  RangeSegment,
-  specialDayArraySegmentFactories,
-  specialDaySegmentFactories,
-  StepSegment,
-  ValueSegment,
-} from './cron'
 export { createL10n, L10nEngine } from './locale'
 export type * from './locale/types'
 export type * from './types'

--- a/core/src/locale/cn.ts
+++ b/core/src/locale/cn.ts
@@ -25,6 +25,10 @@ const locale: Localization = {
       noSpecific: {
         text: '无特定日期',
       },
+      lastDay: { text: '最后一天' },
+      lastDayOffset: { text: '最后一天前{{offset.text}}天' },
+      lastWeekday: { text: '最后一个工作日' },
+      nearestWeekday: { text: '最接近{{value.text}}号的工作日' },
     },
     dayOfWeek: {
       '*': { prefix: '的' },

--- a/core/src/locale/da.ts
+++ b/core/src/locale/da.ts
@@ -24,6 +24,10 @@ const locale: Localization = {
       noSpecific: {
         text: 'ingen specifik dag',
       },
+      lastDay: { text: 'den sidste dag' },
+      lastDayOffset: { prefix: '', text: '{{offset.text}} dag(e) før den sidste dag' },
+      lastWeekday: { text: 'den sidste hverdag' },
+      nearestWeekday: { text: 'den nærmeste hverdag til den {{value.text}}.' },
     },
 
     dayOfWeek: {

--- a/core/src/locale/de.ts
+++ b/core/src/locale/de.ts
@@ -33,6 +33,10 @@ const locale: Localization = {
         prefix: 'an',
         text: 'keinem bestimmten Tag',
       },
+      lastDay: { text: 'letzten Tag' },
+      lastDayOffset: { prefix: '', text: '{{offset.text}} Tag(e) vor dem letzten Tag' },
+      lastWeekday: { text: 'letzten Werktag' },
+      nearestWeekday: { text: 'nächstgelegenen Werktag zum {{value.text}}.' },
     },
     dayOfWeek: {
       '*': { prefix: 'am' },

--- a/core/src/locale/en.ts
+++ b/core/src/locale/en.ts
@@ -26,6 +26,10 @@ const locale: Localization = {
       noSpecific: {
         text: 'no specific day',
       },
+      lastDay: { text: 'the last day' },
+      lastDayOffset: { text: '{{offset.text}} day(s) before the last day' },
+      lastWeekday: { text: 'the last weekday' },
+      nearestWeekday: { text: 'the weekday nearest to day {{value.text}}' },
     },
     dayOfWeek: {
       '*': { prefix: 'on' },

--- a/core/src/locale/es.ts
+++ b/core/src/locale/es.ts
@@ -21,6 +21,10 @@ const locale: Localization = {
       '*': { prefix: 'en' },
       any: { text: 'todos los días' },
       value: { text: 'los días {{ value.alt }}' },
+      lastDay: { text: 'el último día' },
+      lastDayOffset: { prefix: '', text: '{{offset.text}} día(s) antes del último día' },
+      lastWeekday: { text: 'el último día laborable' },
+      nearestWeekday: { text: 'el día laborable más cercano al {{value.text}}' },
     },
     dayOfWeek: {
       '*': { prefix: 'de' },

--- a/core/src/locale/fr.ts
+++ b/core/src/locale/fr.ts
@@ -24,6 +24,10 @@ const locale: Localization = {
       any: { prefix: 'à', text: 'tous les jours' },
       step: { prefix: '', text: 'tous les {{step.value}} jours' },
       noSpecific: { prefix: 'à', text: 'aucun jour particulier' },
+      lastDay: { text: 'dernier jour' },
+      lastDayOffset: { prefix: '', text: '{{offset.text}} jour(s) avant le dernier jour' },
+      lastWeekday: { text: 'dernier jour ouvré' },
+      nearestWeekday: { text: 'jour ouvré le plus proche du {{value.text}}' },
     },
     dayOfWeek: {
       '*': { prefix: 'le' },

--- a/core/src/locale/he.ts
+++ b/core/src/locale/he.ts
@@ -23,6 +23,10 @@ const locale: Localization = {
       noSpecific: {
         text: 'ללא יום מוגדר',
       },
+      lastDay: { text: 'יום האחרון בחודש' },
+      lastDayOffset: { prefix: '', text: '{{offset.text}} ימים לפני היום האחרון בחודש' },
+      lastWeekday: { text: 'יום העסקים האחרון בחודש' },
+      nearestWeekday: { text: 'יום העסקים הקרוב ל-{{value.text}} בחודש' },
     },
     dayOfWeek: {
       '*': { prefix: 'ב' },

--- a/core/src/locale/hi.ts
+++ b/core/src/locale/hi.ts
@@ -24,6 +24,10 @@ const locale: Localization = {
       any: { prefix: 'पर', text: 'हर दिन' },
       step: { prefix: '', text: '{{step.value}} दिन हर' },
       noSpecific: { prefix: 'पर', text: 'कोई विशेष दिन नहीं' },
+      lastDay: { text: 'अंतिम दिन' },
+      lastDayOffset: { prefix: '', text: 'अंतिम दिन से {{offset.text}} दिन पहले' },
+      lastWeekday: { text: 'अंतिम कार्यदिवस' },
+      nearestWeekday: { text: '{{value.text}} तारीख के निकटतम कार्यदिवस' },
     },
     dayOfWeek: {
       '*': { prefix: 'पर' },

--- a/core/src/locale/it.ts
+++ b/core/src/locale/it.ts
@@ -24,6 +24,10 @@ const locale: Localization = {
       any: { prefix: 'il', text: 'ogni giorno' },
       step: { prefix: '', text: 'ogni {{step.value}} giorni' },
       noSpecific: { prefix: 'il', text: 'nessun giorno specifico' },
+      lastDay: { prefix: '', text: "l'ultimo giorno" },
+      lastDayOffset: { prefix: '', text: "{{offset.text}} giorno(i) prima dell'ultimo giorno" },
+      lastWeekday: { prefix: '', text: "l'ultimo giorno feriale" },
+      nearestWeekday: { text: 'giorno feriale più vicino al {{value.text}}' },
     },
     dayOfWeek: {
       '*': { prefix: 'il' },

--- a/core/src/locale/ja.ts
+++ b/core/src/locale/ja.ts
@@ -24,6 +24,10 @@ const locale: Localization = {
       any: { prefix: 'に', text: '毎日' },
       step: { prefix: '', text: '{{step.value}}日ごとに' },
       noSpecific: { prefix: 'に', text: '特定の日はなし' },
+      lastDay: { text: '最終日' },
+      lastDayOffset: { text: '最終日の{{offset.text}}日前' },
+      lastWeekday: { text: '最終営業日' },
+      nearestWeekday: { text: '{{value.text}}日に最も近い平日' },
     },
     dayOfWeek: {
       '*': { prefix: 'の' },

--- a/core/src/locale/ko.ts
+++ b/core/src/locale/ko.ts
@@ -21,6 +21,10 @@ const locale: Localization = {
       any: { prefix: '에', text: '매일' },
       step: { prefix: '', text: '{{step.value}}일마다' },
       noSpecific: { prefix: '에', text: '특정한 날 없음' },
+      lastDay: { text: '마지막 날' },
+      lastDayOffset: { text: '마지막 날 {{offset.text}}일 전' },
+      lastWeekday: { text: '마지막 평일' },
+      nearestWeekday: { text: '{{value.text}}일에 가장 가까운 평일' },
     },
     dayOfWeek: {
       '*': { prefix: '의' },

--- a/core/src/locale/pt.ts
+++ b/core/src/locale/pt.ts
@@ -20,6 +20,10 @@ const locale: Localization = {
     day: {
       '*': { prefix: 'no(s) dia(s)' },
       any: { text: 'todos' },
+      lastDay: { prefix: 'no', text: 'último dia' },
+      lastDayOffset: { prefix: '', text: '{{offset.text}} dia(s) antes do último dia' },
+      lastWeekday: { prefix: 'no', text: 'último dia útil' },
+      nearestWeekday: { prefix: 'no', text: 'dia útil mais próximo do dia {{value.text}}' },
     },
     dayOfWeek: {
       '*': { prefix: 'de' },

--- a/core/src/locale/ru.ts
+++ b/core/src/locale/ru.ts
@@ -24,6 +24,10 @@ const locale: Localization = {
       any: { prefix: 'в', text: 'каждый день' },
       step: { prefix: '', text: 'каждые {{step.value}} дня' },
       noSpecific: { prefix: 'в', text: 'нет определенного дня' },
+      lastDay: { text: 'последний день' },
+      lastDayOffset: { prefix: 'за', text: '{{offset.text}} дн. до последнего дня' },
+      lastWeekday: { text: 'последний рабочий день' },
+      nearestWeekday: { text: 'ближайший рабочий день к {{value.text}} числу' },
     },
     dayOfWeek: {
       '*': { prefix: 'по' },

--- a/core/src/locale/uk.ts
+++ b/core/src/locale/uk.ts
@@ -24,6 +24,10 @@ const locale: Localization = {
       any: { prefix: 'в', text: 'кожний день' },
       step: { prefix: '', text: 'кожні {{step.value}} дні' },
       noSpecific: { prefix: 'в', text: 'немає визначеного дня' },
+      lastDay: { text: 'останній день' },
+      lastDayOffset: { prefix: 'за', text: '{{offset.text}} дн. до останнього дня' },
+      lastWeekday: { text: 'останній робочий день' },
+      nearestWeekday: { text: 'найближчий робочий день до {{value.text}} числа' },
     },
     dayOfWeek: {
       '*': { prefix: 'по' },

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -3,15 +3,21 @@ import type { UseCronSegmentReturn } from './components/cron-segment'
 
 export type CronFormat = 'crontab' | 'quartz' | 'spring'
 
+/**
+ * Value of a cron segment. Numbers refer to the values of a field, e.g. `1` (January).
+ * Strings refer to special values, e.g. `L` (last day of the month).
+ */
+export type FieldValue = number | string
+
 export interface CronSegment {
   field: FieldWrapper
   type: FieldPattern
   toCron: () => string
-  toArray: () => number[]
+  toArray: () => FieldValue[]
   items: Record<string, FieldItem>
 }
 
-export type SegmentFromArray = (arr: number[], field: FieldWrapper) => CronSegment | null
+export type SegmentFromArray = (arr: FieldValue[], field: FieldWrapper) => CronSegment | null
 export type SegmentFromString = (str: string, field: FieldWrapper) => CronSegment | null
 
 export enum FieldPattern {
@@ -23,6 +29,35 @@ export enum FieldPattern {
   RangeStep = 'rangeStep', // a-b/x
   Combined = 'combined',
   NoSpecific = 'noSpecific', // ?
+  LastDay = 'lastDay', // L
+  LastDayOffset = 'lastDayOffset', // L-a
+  LastWeekday = 'lastWeekday', // LW
+  NearestWeekday = 'nearestWeekday', // aW
+}
+
+/**
+ * Patterns, which can't be expressed as a list of {@link FieldValue | field values}
+ */
+const specialPatterns: ReadonlySet<FieldPattern> = new Set([
+  FieldPattern.NoSpecific,
+  FieldPattern.LastDay,
+  FieldPattern.LastDayOffset,
+  FieldPattern.LastWeekday,
+  FieldPattern.NearestWeekday,
+])
+
+/**
+ * @returns true, if the pattern is a special pattern, such as {@link FieldPattern.LastDay}
+ */
+export function isSpecialPattern(pattern: FieldPattern) {
+  return specialPatterns.has(pattern)
+}
+
+/**
+ * @returns true, if the value is a special value, such as `L`
+ */
+export function isSpecialValue(value: FieldValue): value is string {
+  return typeof value === 'string'
 }
 
 export enum TextPosition {
@@ -37,11 +72,38 @@ export interface FieldItem {
   alt: string
 }
 
+/**
+ * An item, which represents a special value of a field, e.g. `L` (last day of the month).
+ * Special items are appended to the items of a field, but they are not part of
+ * {@link FieldWrapper.items}, because they don't take part in ranges and steps.
+ */
+export interface SpecialItem {
+  value: string
+  text: string
+  alt: string
+}
+
+export type SelectItem = FieldItem | SpecialItem
+
 export interface Field {
   id: string
   items: FieldItem[]
   onChange?: (segment: UseCronSegmentReturn, ctx: CronContext) => void
+  /**
+   * Factories to convert a cron segment into a {@link CronSegment},
+   * defaults to `CombinedSegment.segmentFactories`
+   */
   segmentFactories?: SegmentFromString[]
+  /**
+   * Factories to convert the selected values into a {@link CronSegment},
+   * defaults to `defaultArraySegmentFactories`
+   *
+   * Note: `segmentFactories` and `arraySegmentFactories` should support the same patterns,
+   * otherwise the selected values can't be converted back into a cron segment.
+   */
+  arraySegmentFactories?: SegmentFromArray[]
+  /** Items of special values, such as `L`, which can be selected in addition to `items` */
+  specialItems?: SpecialItem[]
   default?: string
 }
 
@@ -68,6 +130,7 @@ interface FieldContext {
 export class FieldWrapper {
   field: Field
   itemMap: Record<number, FieldItem>
+  specialItemMap: Record<string, SpecialItem>
   ctx: FieldContext
 
   constructor(field: Field, ctx: FieldContext) {
@@ -80,6 +143,14 @@ export class FieldWrapper {
         return acc
       },
       {} as Record<number, FieldItem>,
+    )
+
+    this.specialItemMap = this.specialItems.reduce(
+      (acc, item) => {
+        acc[item.value] = item
+        return acc
+      },
+      {} as Record<string, SpecialItem>,
     )
   }
 
@@ -95,6 +166,16 @@ export class FieldWrapper {
   get segmentFactories() {
     return this.field.segmentFactories
   }
+  get arraySegmentFactories() {
+    return this.field.arraySegmentFactories
+  }
+  get specialItems() {
+    return this.field.specialItems ?? []
+  }
+  /** items and special items of the field */
+  get allItems(): SelectItem[] {
+    return [...this.items, ...this.specialItems]
+  }
 
   get min() {
     return this.items[0].value
@@ -106,5 +187,9 @@ export class FieldWrapper {
 
   getItem(value: number) {
     return this.itemMap[value]
+  }
+
+  getSpecialItem(value: string) {
+    return this.specialItemMap[value]
   }
 }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -75,7 +75,7 @@ export interface FieldItem {
 /**
  * An item, which represents a special value of a field, e.g. `L` (last day of the month).
  * Special items are appended to the items of a field, but they are not part of
- * {@link FieldWrapper.items}, because they don't take part in ranges and steps.
+ * {@link FieldWrapper#items}, because they don't take part in ranges and steps.
  */
 export interface SpecialItem {
   value: string

--- a/docs/src/.vuepress/components/special-values-crontab.vue
+++ b/docs/src/.vuepress/components/special-values-crontab.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <div class="mb-2">{{ value }}</div>
+    <CronLight v-model="value" :fields="fields" @error="error = $event" />
+  </div>
+</template>
+
+<script>
+import { createL10n, DefaultCronOptions, withSpecialDays } from '@vue-js-cron/core'
+
+const locale = 'en'
+const l10n = createL10n(locale)
+
+export default {
+  data() {
+    return {
+      value: '0 0 L * *',
+      error: '',
+      fields: new DefaultCronOptions()
+        .fields('crontab', locale, l10n)
+        .map((field) => (field.id === 'day' ? withSpecialDays(field, l10n) : field)),
+    }
+  },
+}
+</script>

--- a/docs/src/.vuepress/components/special-values-crontab.vue
+++ b/docs/src/.vuepress/components/special-values-crontab.vue
@@ -6,10 +6,9 @@
 </template>
 
 <script>
-import { createL10n, DefaultCronOptions, withSpecialDays } from '@vue-js-cron/core'
+import { DefaultCronOptions, withSpecialDays } from '@vue-js-cron/core'
 
 const locale = 'en'
-const l10n = createL10n(locale)
 
 export default {
   data() {
@@ -17,8 +16,8 @@ export default {
       value: '0 0 L * *',
       error: '',
       fields: new DefaultCronOptions()
-        .fields('crontab', locale, l10n)
-        .map((field) => (field.id === 'day' ? withSpecialDays(field, l10n) : field)),
+        .fields('crontab', locale)
+        .map((field) => (field.id === 'day' ? withSpecialDays(field) : field)),
     }
   },
 }

--- a/docs/src/.vuepress/components/special-values.vue
+++ b/docs/src/.vuepress/components/special-values.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <div class="mb-2">{{ value }}</div>
+    <CronLight v-model="value" format="quartz" @error="error = $event" />
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      value: '0 0 0 L * ?',
+      error: '',
+    }
+  },
+}
+</script>

--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -81,6 +81,7 @@ export default defineUserConfig({
             'getting-started-vuetify',
             'custom-periods',
             'custom-fields',
+            'special-values',
           ],
         },
       ],

--- a/docs/src/guide/special-values.md
+++ b/docs/src/guide/special-values.md
@@ -1,0 +1,28 @@
+# Special Values
+
+The day of month field of the `quartz` and `spring` format supports the special values `L` and `W`.
+
+| Value | Description                              |
+| ----- | ---------------------------------------- |
+| `L`   | last day of the month                    |
+| `L-3` | 3 days before the last day of the month  |
+| `LW`  | last weekday of the month                |
+| `15W` | weekday nearest to the 15th of the month |
+
+`L` and `LW` are part of the items of the day field, therefore they can be selected like any
+other value. `L-<n>` and `<n>W` are parsed and displayed, but they have to be set through
+`v-model`.
+
+Special values can't be combined with other values, e.g. `L,15` is not a valid day of month.
+
+<special-values />
+
+## Other formats
+
+The special values are disabled for the `crontab` format, because
+[crontab](https://linux.die.net/man/5/crontab) doesn't support them.
+`withSpecialDays` enables them for any format.
+
+@[code](@/src/.vuepress/components/special-values-crontab.vue)
+
+<special-values-crontab />


### PR DESCRIPTION
Adds the special day of month values `L` and `W` to `@vue-js-cron/core`. Closes #61, related: #25.

## Semantics (quartz and spring, day of month)

| value | meaning |
| --- | --- |
| `L` | last day of the month |
| `L-3` | 3 days before the last day of the month |
| `LW` | last weekday of the month |
| `15W` | weekday nearest to the 15th of the month |

`L` and `LW` are added to the items of the day field, therefore they can be selected from the dropdown. `L-<n>` and `<n>W` are parsed, displayed and preserved, but they aren't offered as items — see *Not included*.

Special values can't be combined with other values: `L,15` is rejected, selecting a day replaces `L` and vice versa.

The values are enabled for `quartz` and `spring`, the `crontab` format is unchanged. `withSpecialDays` enables them for any format:

```ts
const fields = new DefaultCronOptions()
  .fields('crontab', 'en')
  .map((field) => (field.id === 'day' ? withSpecialDays(field) : field))
```

## Why this isn't only a new segment class

Parsing was already extensible: `CombinedSegment.fromString` looks up `field.segmentFactories`. Building the expression from the selected values wasn't: `arrayToSegment` was hardcoded to `AnySegment`, `StepSegment` and `CombinedSegment`, and the selected values were `number[]`, so `ValueSegment.toCron()` printed a number. A parsed `L` lived until the first `selected -> cron` watcher and was silently replaced.

This PR makes both directions symmetric:

- `Field.arraySegmentFactories` next to `Field.segmentFactories`, used by `arrayToSegment`
- a selected value is `number | string` (`FieldValue`), where strings are special tokens
- `Field.specialItems` holds the items of special values. They are kept out of `FieldWrapper.items`, so `min`, `max`, ranges and steps are unaffected; `FieldWrapper.allItems` is what the editor renders
- `useCronSegment` keeps the current expression while a special value is set and nothing is selected. This generalizes the former special case of `?`
- `withSpecialDays` and `DefaultCronOptions` are exported, so the values can be enabled for any format from outside the package. Everything in `./cron` stays internal

## Localization

The patterns `lastDay`, `lastDayOffset`, `lastWeekday` and `nearestWeekday` are translated in
**every** locale. A missing translation doesn't stay empty — since every locale is merged into `en`,
it shows up as english text in the middle of a translated expression
(`Каждый Месяц в the last day ...`), so I followed how `noSpecific` was rolled out with the quartz
format. `locale.spec.ts` asserts that no locale falls back to the english text.

| locale | `L` | `15W` |
| --- | --- | --- |
| de | den letzten Tag | den nächstgelegenen Werktag zum 15. |
| ru | в последний день | в ближайший рабочий день к 15 числу |
| fr | le dernier jour | le jour ouvré le plus proche du 15 |
| zh | 最后一天 | 最接近15号的工作日 |
| ja | 最終日 | 15日に最も近い平日 |

Please have a look at the wording in the languages you speak. I'm confident about `en`, `de`, `ru`
and `uk`; the rest were written the same way as the machine-assisted translations already in the
repository and are trivial to adjust — it's four strings per file.

The item text of `L` and `LW` is the token itself, because the items are rendered in a grid and a long label stretches the dropdown. The selected value is spelled out by the editor: *Every Month on the last day at 00 : 00 : 00*.

## Not included

Happy to follow up on any of these:

- day of week: `L` (= Saturday), `<n>L` (e.g. `6L`) and `#` (e.g. `6#3`)
- `C` (calendar)
- `L-<n>` and `<n>W` as selectable items: 61 additional entries in the day dropdown wouldn't be usable, they need a different input than the item grid

If you'd rather track the day of week values separately, just unlink #61 and I'll open a follow-up issue for them.

## Compatibility

- `FieldItem`, `FieldWrapper.items`, `min`, `max` and `getItem` are unchanged
- `CronSegment.toArray()`, `SegmentFromArray` and the selected values widen from `number[]` to `(number | string)[]`

Nothing changes at runtime, but the widened types can break a TypeScript consumer which assigns
`toArray()` or the selected values to `number[]`. The commit is `feat(core)`, so semantic-release
would publish it as a minor. If you'd rather treat it as breaking, say the word and I'll add a
`BREAKING CHANGE:` footer to the commit.

## Tests

`npm run lint`, `npm run build` and `npm run test` pass. Added tests cover:

- parsing and building of `L`, `L-<n>`, `LW`, `<n>W`, including the invalid cases (`W`, `L-0`, `L-31`, `32W`, `L,5`)
- the round trip `cron -> segment -> cron`, for quartz (`0 0 0 L * ?`) and for crontab with opt-in (`0 0 L * *`)
- `crontab` is unchanged without opt-in: `L` is reported as an invalid segment and the day field has 31 items
- the exclusivity rules of special values
- `useCronSegment` together with `useSelect`: a special value stays selected when the expression is set from outside, and a value without an item (`L-3`) isn't dropped by the select
- every locale translates the four new patterns instead of falling back to english

Verified manually with `@vue-js-cron/light` (quartz): selecting `L`/`LW`, replacing them by a day, and setting `L-3`, `15W` and `L,5` through `v-model`.
