### PR TITLE
docs: document themes and dark mode of cron-light

### DIFF
--- a/docs/src/.vuepress/components/light-theming.vue
+++ b/docs/src/.vuepress/components/light-theming.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <div class="mb-2">{{ value }}</div>
+
+    <p class="pb-1">theme: ant (default)</p>
+    <CronLight v-model="value" />
+
+    <p class="pb-1 pt-4">theme: legacy</p>
+    <CronLight v-model="value" theme="legacy" />
+
+    <p class="pb-1 pt-4">dark mode</p>
+    <div class="dark" style="padding: 1rem; background-color: #0d1117">
+      <CronLight v-model="value" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      value: '0 9 * * 1-5',
+    }
+  },
+}
+</script>

--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -73,6 +73,7 @@ export default defineUserConfig({
           children: [
             'getting-started-core',
             'getting-started-light',
+            'light-theming',
             'getting-started-ant',
             'getting-started-element-plus',
             'getting-started-naive-ui',

--- a/docs/src/guide/light-theming.md
+++ b/docs/src/guide/light-theming.md
@@ -1,0 +1,33 @@
+# Theming - Light
+
+## Themes
+
+`CronLight` ships two themes, which are selected with the `theme` prop.
+
+| value | description |
+| -------- | -------------------------------------------------------------- |
+| `ant` | default theme, inspired by [Ant Design Vue](https://antdv.com/) |
+| `legacy` | the styles used before the `ant` theme was introduced |
+
+```vue
+<template>
+  <cron-light v-model="value" theme="legacy" />
+</template>
+```
+
+## Dark mode
+
+Dark mode is activated by adding the `dark` class to any parent element.
+
+```html
+<body class="dark">
+  <cron-light v-model="value" />
+</body>
+```
+
+Note: the dark styles are defined for the `ant` theme, the `legacy` theme doesn't provide a
+dark variant.
+
+@[code](@/src/.vuepress/components/light-theming.vue)
+
+<light-theming />


### PR DESCRIPTION
Documents the `theme` prop and dark mode of `@vue-js-cron/light`.

Closes #84, closes #80. Both are about the same page of the guide, so they are documented together — if you'd rather have them separated, I'll split the page.

The new page is hand written (like `custom-fields` and `custom-periods`), because the `getting-started-*` pages are generated.

## Content

- the `theme` prop: `ant` (default, inspired by Ant Design Vue) and `legacy`
- dark mode: the `dark` class on any parent element
- a live example of both themes and of dark mode

## One detail worth confirming

The dark styles are declared as `.dark .ant` in `light/src/theme/ant.css`, so they only apply to
the `ant` theme — `theme="legacy"` has no dark variant. I documented it as a note. If that is
unintended, I'm happy to send the styles for `legacy` as a separate PR instead.

`npm run lint` and the VuePress build pass, the page renders with all three examples.
