### PR TITLE
docs: document the required typescript version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Vue v3: [documentation](https://abichinger.github.io/vue-js-cron)
 
 Vue v2: [documentation](https://abichinger.github.io/vue-js-cron/vue2)
 
+# Requirements
+
+The type declarations of `vue-js-cron` require `typescript >= 5`, if your project uses TypeScript.
+
 # Packages
 
 This monorepo includes the following packages:

--- a/docs/src/guide/getting-started-ant.md
+++ b/docs/src/guide/getting-started-ant.md
@@ -11,11 +11,11 @@ The fastest way to get started, is to use one of the prebuilt components.
 - [cron-quasar](./getting-started-quasar) - cron editor for [Quasar](https://quasar.dev/)
 - [cron-vuetify](./getting-started-vuetify) - cron editor for [Vuetify.js](https://next.vuetifyjs.com/en/)
 
-
 ## Requirements
 
 Make sure to install and setup all requirements.
 - [Ant Design Vue](https://www.antdv.com/components/overview/)
+- [TypeScript](https://www.typescriptlang.org/) >= 5 - only required, if your project uses TypeScript
 
 ## Installation
 

--- a/docs/src/guide/getting-started-core.md
+++ b/docs/src/guide/getting-started-core.md
@@ -11,7 +11,10 @@ The fastest way to get started, is to use one of the prebuilt components.
 - [cron-quasar](./getting-started-quasar) - cron editor for [Quasar](https://quasar.dev/)
 - [cron-vuetify](./getting-started-vuetify) - cron editor for [Vuetify.js](https://next.vuetifyjs.com/en/)
 
+## Requirements
 
+Make sure to install and setup all requirements.
+- [TypeScript](https://www.typescriptlang.org/) >= 5 - only required, if your project uses TypeScript
 
 ## Installation
 

--- a/docs/src/guide/getting-started-element-plus.md
+++ b/docs/src/guide/getting-started-element-plus.md
@@ -11,11 +11,11 @@ The fastest way to get started, is to use one of the prebuilt components.
 - [cron-quasar](./getting-started-quasar) - cron editor for [Quasar](https://quasar.dev/)
 - [cron-vuetify](./getting-started-vuetify) - cron editor for [Vuetify.js](https://next.vuetifyjs.com/en/)
 
-
 ## Requirements
 
 Make sure to install and setup all requirements.
 - [Element Plus](https://element-plus.org/en-US/)
+- [TypeScript](https://www.typescriptlang.org/) >= 5 - only required, if your project uses TypeScript
 
 ## Installation
 

--- a/docs/src/guide/getting-started-light.md
+++ b/docs/src/guide/getting-started-light.md
@@ -11,7 +11,10 @@ The fastest way to get started, is to use one of the prebuilt components.
 - [cron-quasar](./getting-started-quasar) - cron editor for [Quasar](https://quasar.dev/)
 - [cron-vuetify](./getting-started-vuetify) - cron editor for [Vuetify.js](https://next.vuetifyjs.com/en/)
 
+## Requirements
 
+Make sure to install and setup all requirements.
+- [TypeScript](https://www.typescriptlang.org/) >= 5 - only required, if your project uses TypeScript
 
 ## Installation
 

--- a/docs/src/guide/getting-started-naive-ui.md
+++ b/docs/src/guide/getting-started-naive-ui.md
@@ -11,11 +11,11 @@ The fastest way to get started, is to use one of the prebuilt components.
 - [cron-quasar](./getting-started-quasar) - cron editor for [Quasar](https://quasar.dev/)
 - [cron-vuetify](./getting-started-vuetify) - cron editor for [Vuetify.js](https://next.vuetifyjs.com/en/)
 
-
 ## Requirements
 
 Make sure to install and setup all requirements.
 - [Naive UI](https://www.naiveui.com/en-US/os-theme/docs/installation)
+- [TypeScript](https://www.typescriptlang.org/) >= 5 - only required, if your project uses TypeScript
 
 ## Installation
 

--- a/docs/src/guide/getting-started-prime.md
+++ b/docs/src/guide/getting-started-prime.md
@@ -11,11 +11,11 @@ The fastest way to get started, is to use one of the prebuilt components.
 - [cron-quasar](./getting-started-quasar) - cron editor for [Quasar](https://quasar.dev/)
 - [cron-vuetify](./getting-started-vuetify) - cron editor for [Vuetify.js](https://next.vuetifyjs.com/en/)
 
-
 ## Requirements
 
 Make sure to install and setup all requirements.
 - [PrimeVue](https://primevue.org/setup/)
+- [TypeScript](https://www.typescriptlang.org/) >= 5 - only required, if your project uses TypeScript
 
 ## Installation
 

--- a/docs/src/guide/getting-started-quasar.md
+++ b/docs/src/guide/getting-started-quasar.md
@@ -11,11 +11,11 @@ The fastest way to get started, is to use one of the prebuilt components.
 - cron-quasar - cron editor for [Quasar](https://quasar.dev/)
 - [cron-vuetify](./getting-started-vuetify) - cron editor for [Vuetify.js](https://next.vuetifyjs.com/en/)
 
-
 ## Requirements
 
 Make sure to install and setup all requirements.
 - [Quasar](https://quasar.dev/start)
+- [TypeScript](https://www.typescriptlang.org/) >= 5 - only required, if your project uses TypeScript
 
 ## Installation
 

--- a/docs/src/guide/getting-started-vuetify.md
+++ b/docs/src/guide/getting-started-vuetify.md
@@ -11,11 +11,11 @@ The fastest way to get started, is to use one of the prebuilt components.
 - [cron-quasar](./getting-started-quasar) - cron editor for [Quasar](https://quasar.dev/)
 - cron-vuetify - cron editor for [Vuetify.js](https://next.vuetifyjs.com/en/)
 
-
 ## Requirements
 
 Make sure to install and setup all requirements.
 - [Vuetify](https://next.vuetifyjs.com/en/)
+- [TypeScript](https://www.typescriptlang.org/) >= 5 - only required, if your project uses TypeScript
 
 ## Installation
 

--- a/generated/bin/templates/getting-started.md.njk
+++ b/generated/bin/templates/getting-started.md.njk
@@ -11,15 +11,14 @@ The fastest way to get started, is to use one of the prebuilt components.
 {%- endif %}
 {%- endfor %}
 
-{% if flavor.requirements %}
 ## Requirements
 
 Make sure to install and setup all requirements.
 
-{%- for r in flavor.requirements %}
+{%- for r in flavor.requirements or [] %}
 - [{{ r.name }}]({{ r.url }})
 {%- endfor %}
-{%- endif %}
+- [TypeScript](https://www.typescriptlang.org/) >= 5 - only required, if your project uses TypeScript
 
 ## Installation
 

--- a/generated/src/templates/getting-started.md.njk
+++ b/generated/src/templates/getting-started.md.njk
@@ -11,15 +11,14 @@ The fastest way to get started, is to use one of the prebuilt components.
 {%- endif %}
 {%- endfor %}
 
-{% if flavor.requirements %}
 ## Requirements
 
 Make sure to install and setup all requirements.
 
-{%- for r in flavor.requirements %}
+{%- for r in flavor.requirements or [] %}
 - [{{ r.name }}]({{ r.url }})
 {%- endfor %}
-{%- endif %}
+- [TypeScript](https://www.typescriptlang.org/) >= 5 - only required, if your project uses TypeScript
 
 ## Installation
 


### PR DESCRIPTION
Documents that `vue-js-cron` needs `typescript >= 5`.

Closes #59.

## Why the requirement is real

The published type declarations contain `export type * from './types'` (`core/dist/index.d.ts`),
and `export type *` was added in TypeScript 5.0 — a project on TypeScript 4 fails at build time,
which is exactly what happened in #58, where upgrading TypeScript fixed it.

## What changed

- `generated/src/templates/getting-started.md.njk`: the `Requirements` section is no longer
  conditional and always lists TypeScript. The section was only rendered for flavors which bring
  their own requirements (`ant`, `element-plus`, …), so `core` and `light` had none at all.
- the eight `getting-started-*` pages regenerated with `cron-cli guide` (and the copy of the
  template under `generated/bin`, which is checked in)
- a short `Requirements` section in the root `README.md`

I left the per-package `README.md` files alone to keep the diff small — happy to add the note to
`README.md.njk` and regenerate them as well, since npm shows those.
